### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,7 @@
 NAME="jmeter"
 IMAGE="justb4/jmeter:3.3"
 
-# Use the current working dir
-WORK_DIR="`pwd`"
-
 # Finally run
 sudo docker stop ${NAME} > /dev/null 2>&1
 sudo docker rm ${NAME} > /dev/null 2>&1
-sudo docker run --name ${NAME} -i -v ${WORK_DIR}:${WORK_DIR} -w ${WORK_DIR} ${IMAGE} $@
-
+sudo docker run --name ${NAME} -i -v ${PWD}:${PWD} -w ${PWD} ${IMAGE} $@


### PR DESCRIPTION
### Issue to solve
Unnecessary variable on `run.sh`.

### Why is this an issue?
There's no need to make a variable `WORD_DIR` when there's already one called `PWD` available through the shell's environment.

### How was it solved?
Editing `run.sh` so it makes use of `PWD`.

### Tested
I have tested this with the following:
```shell
Client:
 Version:           18.06.1-ce
 API version:       1.38
 Go version:        go1.11
 Git commit:        e68fc7a215
 Built:             Fri Sep  7 11:26:59 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.1-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.11
  Git commit:       e68fc7a215
  Built:            Fri Sep  7 11:26:11 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```