### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8
 
 MAINTAINER Just van den Broecke<just@justobjects.nl>
 
-ARG JMETER_VERSION="3.3"
+ARG JMETER_VERSION="5.0"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz


### PR DESCRIPTION
**Updated the Jmeter with version 5.0.**

**Reason for update JMeter version:** I was using 5.0 for JMX creation and while running in docker image(justb4),  it was returning below error. I thought to set up an image with Jmeter 5.0 docker file.

Error in NonGUIDriver java.lang.IllegalArgumentException: Problem loading XML from:'/jmeter/organisation.jmx', missing class com.thoughtworks.xstream.converters.ConversionException:
---- Debugging information ----
cause-exception     : com.thoughtworks.xstream.converters.ConversionException
cause-message       :
first-jmeter-class  : org.apache.jmeter.save.converters.HashTreeConverter.unmarshal(HashTreeConverter.java:67)
class               : org.apache.jmeter.save.ScriptWrapper
required-type       : org.apache.jorphan.collections.ListedHashTree
converter-type      : org.apache.jmeter.save.ScriptWrapperConverter
path                : /jmeterTestPlan/hashTree/hashTree/kg.apc.jmeter.threads.UltimateThreadGroup
line number         : 789
version             : 4.0 r1823414