### PR TITLE
Added plugin support and upgrade jdk version to 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docker-remove-all.sh
 **/report/
 **/*.jtl
 **/*.log
+plugins/*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN    apk update \
 	&& apk upgrade \
 	&& apk add ca-certificates \
 	&& update-ca-certificates \
-	&& apk add --update openjdk8-jre tzdata curl unzip bash \
+	&& apk add --update openjdk11-jre tzdata curl unzip bash \
 	&& apk add --no-cache nss \
 	&& rm -rf /var/cache/apk/* \
 	&& mkdir -p /tmp/dependencies  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG JMETER_VERSION="5.3"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
+ENV JMETER_PLUGINS ${JMETER_HOME}/lib/ext/
 
 # Install extra packages
 # Set TimeZone, See: https://github.com/gliderlabs/docker-alpine/issues/136#issuecomment-612751142
@@ -26,8 +27,8 @@ RUN    apk update \
 	&& tar -xzf /tmp/dependencies/apache-jmeter-${JMETER_VERSION}.tgz -C /opt  \
 	&& rm -rf /tmp/dependencies
 
-# TODO: plugins (later)
-# && unzip -oq "/tmp/dependencies/JMeterPlugins-*.zip" -d $JMETER_HOME
+# plugins
+ADD plugins/*.jar ${JMETER_PLUGINS}
 
 # Set global PATH such that "jmeter" command is found
 ENV PATH $PATH:$JMETER_BIN

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ of the pre-built Images from [Docker Hub](https://hub.docker.com/r/justb4/jmeter
 
 See end of this doc for more detailed build/run/test instructions (thanks to @wilsonmar!)
 
+### Plugins
+
+For adding plugins to the built image, place all jar files inside a `plugins` dirs in the root of this project.
+
 ### Build Options
 
 Build arguments (see [build.sh](build.sh)) with default values if not passed to build:


### PR DESCRIPTION
Hi,

I have added some support for adding plugins at build time and since the plugin i am using needs jdk11, i also did upgrade the version used to `openjdk11-jre`.

Could you please consider including this in main stream?

Thanks in advance,
David