### PR TITLE
update jmeter to 5.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.12
 
 MAINTAINER Just van den Broecke<just@justobjects.nl>
 
-ARG JMETER_VERSION="5.4"
+ARG JMETER_VERSION="5.4.2"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz


### PR DESCRIPTION
update jmeter to 5.4.2 for security CVE-2021-45046 & CVE-2021-45046 as formatMsgNoLookups is not suffisent

https://jmeter.apache.org/changes.html#Non-functional%20changes

Other insufficient mitigation measures are: setting system property log4j2.formatMsgNoLookups or environment variable LOG4J_FORMAT_MSG_NO_LOOKUPS to true for releases >= 2.10, or modifying the logging configuration to disable message lookups with %m{nolookups}, %msg{nolookups} or %message{nolookups} for releases >= 2.7 and <= 2.14.1.