### PR TITLE
Fix plugin installation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@
 if [ -d /plugins ]
 then
     for plugin in /plugins/*.jar; do
-        cp $plugin $(pwd)/lib/ext
+        cp $plugin $(JMETER_HOME)/lib/ext
     done;
 fi
 


### PR DESCRIPTION
## Overview

Related issue: https://github.com/justb4/docker-jmeter/issues/44

Modified the `entrypoint.sh` script to use `$JMETER_HOME` for the plugin installation destination since the preferred method to run the container is by setting the `working_dir` flag in order to mount custom jmx scripts. For example:

```sh
> docker run --rm --name jmeter -i -v ${PWD}/plugins:/plugins -v ${PWD}:${PWD} -w ${PWD} justb4/jmeter:latest -n -t my_custom_file.jmx -l my_output.jtl
```

Behavior before changes would result in the following error:
```
cp: can't create '/my/path/lib/ext': No such file or directory
```

This change essentially makes use of the `$JMETER_HOME` environment variable to properly copy over the plugin .jar files.

