### PR TITLE
Use MemAvailable to compute java memory limits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 
 # Execute JMeter command
 set -e
-freeMem=`awk '/MemFree/ { print int($2/1024) }' /proc/meminfo`
+freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
 s=$(($freeMem/10*8))
 x=$(($freeMem/10*8))
 n=$(($freeMem/10*2))


### PR DESCRIPTION
The `entrypoint.sh` script uses the `MemFree` parameter in
`/proc/meminfo` that only considers non-used memory, and excludes
freeable caches. `MemAvailable` should provide a better estimate for the
memory that a process can use.

Signed-off-by: Darius Mihai <dariusmihaim@gmail.com>