### PR TITLE
fix: use variable instead of command for JMETER_HOME

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@
 if [ -d /plugins ]
 then
     for plugin in /plugins/*.jar; do
-        cp $plugin $(JMETER_HOME)/lib/ext
+        cp $plugin ${JMETER_HOME}/lib/ext
     done;
 fi
 


### PR DESCRIPTION
Quick fix as I accidentally used command notation instead of referencing the $JMETER_HOME variable properly