### PR TITLE
Feature Request: Make /proc/meminfo/ readout optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,19 @@ These are called JMeter User Defined Variables or UDVs.
 See [test.sh](test.sh) and the [trivial test plan](tests/trivial/test-plan.jmx) for an example of UDVs passed to the Docker 
 image via [run.sh](run.sh).
 
-See also: https://www.novatec-gmbh.de/en/blog/how-to-pass-command-line-properties-to-a-jmeter-testplan/
+See also: https://www.novatec-gmbh.de/en/blog/how-to-pass-command-line-properties-to-a-jmeter-testplan/ption
+
+## Adjust Java Memory Options
+
+By default, JMeter reads out the available memory from the host machine and uses a fixed value of 80% of it as a maximum. If this causes Issues, there is the option to use environment variables to adjust the JVM memory Parameters:
+
+```JVM_XMN``` to adjust maximum nursery size
+
+```JVM_XMS``` to adjust initial heap size
+
+```JVM_XMX``` to adjust maximum heap size
+
+All three use values in Megabyte range.
 
 ## Installing JMeter plugins
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,25 +17,11 @@ fi
 set -e
 freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
 
-if [-z $JVM_XMN]; then
-    n=$JVM_XMN
-else 
-    n=$(($freeMem/10*2))
-fi
+[[ -z ${JVM_XMN} ]] && JVM_XMN=$(($freeMem/10*2))
+[[ -z ${JVM_XMS} ]] && JVM_XMS=$(($freeMem/10*8))
+[[ -z ${JVM_XMX} ]] && JVM_XMX=$(($freeMem/10*8))
 
-if [-z $JVM_XMS]; then
-    s=$JVM_XMS
-else
-    s=$(($freeMem/10*8))
-fi
-
-if [-z $JVM_XMX]; then
-    x=$JVM_XMX
-else
-    x=$(($freeMem/10*8))
-fi
-
-export JVM_ARGS="-Xmn${n}m -Xms${s}m -Xmx${x}m"
+export JVM_ARGS="-Xmn${JVM_XMN}m -Xms${JVM_XMS}m -Xmx${JVM_XMX}m"
 
 echo "START Running Jmeter on `date`"
 echo "JVM_ARGS=${JVM_ARGS}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,9 +22,8 @@ do
     if ! ((eoo)); then
 	case "$1" in
 	  -max_memory)
-	      shift
-              freeMem = "$1"
-              shift
+          freeMem="$2"
+          shift 2
 	      ;;
 	  --)
 	      eoo=1
@@ -44,11 +43,10 @@ do
 	shift
     fi
 done
-
 # Execute JMeter command
 set -e
-if (freeMem == {}); then 
-freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
+if [ -z $freeMem ]; then 
+freeMem="999999999"
 fi
 s=$(($freeMem/10*8))
 x=$(($freeMem/10*8))
@@ -58,18 +56,3 @@ export JVM_ARGS="-Xmn${n}m -Xms${s}m -Xmx${x}m"
 echo "START Running Jmeter on `date`"
 echo "JVM_ARGS=${JVM_ARGS}"
 echo "jmeter args=${options[@]}"
-
-# Keep entrypoint simple: we must pass the standard JMeter arguments
-EXTRA_ARGS=-Dlog4j2.formatMsgNoLookups=true
-echo "jmeter ALL ARGS=${EXTRA_ARGS} ${options[@]}"
-jmeter ${EXTRA_ARGS} "${options[@]}"
-
-echo "END Running Jmeter on `date`"
-
-#     -n \
-#    -t "/tests/${TEST_DIR}/${TEST_PLAN}.jmx" \
-#    -l "/tests/${TEST_DIR}/${TEST_PLAN}.jtl"
-# exec tail -f jmeter.log
-#    -D "java.rmi.server.hostname=${IP}" \
-#    -D "client.rmi.localport=${RMI_PORT}" \
-#  -R $REMOTE_HOSTS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,3 +56,18 @@ export JVM_ARGS="-Xmn${n}m -Xms${s}m -Xmx${x}m"
 echo "START Running Jmeter on `date`"
 echo "JVM_ARGS=${JVM_ARGS}"
 echo "jmeter args=${options[@]}"
+
+# Keep entrypoint simple: we must pass the standard JMeter arguments
+EXTRA_ARGS=-Dlog4j2.formatMsgNoLookups=true
+echo "jmeter ALL ARGS=${EXTRA_ARGS} ${options[@]}"
+jmeter ${EXTRA_ARGS} ${options[@]}
+
+echo "END Running Jmeter on `date`"
+
+#     -n \
+#    -t "/tests/${TEST_DIR}/${TEST_PLAN}.jmx" \
+#    -l "/tests/${TEST_DIR}/${TEST_PLAN}.jtl"
+# exec tail -f jmeter.log
+#    -D "java.rmi.server.hostname=${IP}" \
+#    -D "client.rmi.localport=${RMI_PORT}" \
+#  -R $REMOTE_HOSTS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,10 +43,11 @@ do
 	shift
     fi
 done
+
 # Execute JMeter command
 set -e
 if [ -z $freeMem ]; then 
-freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
+    freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
 fi
 s=$(($freeMem/10*8))
 x=$(($freeMem/10*8))

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,8 +23,8 @@ do
 	case "$1" in
 	  -max_memory)
 	      shift
-          freeMem = "$1"
-          shift
+              freeMem = "$1"
+              shift
 	      ;;
 	  --)
 	      eoo=1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ done
 # Execute JMeter command
 set -e
 if [ -z $freeMem ]; then 
-freeMem="999999999"
+freeMem=`awk '/MemAvailable/ { print int($2/1024) }' /proc/meminfo`
 fi
 s=$(($freeMem/10*8))
 x=$(($freeMem/10*8))


### PR DESCRIPTION
**Feature/Problem Description:**
/proc/meminfo/ always reads out the memory of the host machine (see https://fabiokung.com/2014/03/13/memory-inside-linux-containers/).  This is a problem when running the container in a cluster environment like Kubernetes or OpenShift.

**Proposed Solution:** 
Add a new, optional command line parameter to control the "freeMem" parameter, which does not get passed to the jmeter call.

