### PR TITLE
Allow user defining an alternate custom plugin folder location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ MAINTAINER Just van den Broecke<just@justobjects.nl>
 
 ARG JMETER_VERSION="5.4.3"
 ENV JMETER_HOME /opt/apache-jmeter-${JMETER_VERSION}
+ENV JMETER_CUSTOM_PLUGINS_FOLDER /plugins
 ENV	JMETER_BIN	${JMETER_HOME}/bin
 ENV	JMETER_DOWNLOAD_URL  https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.tgz
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ sudo docker run --name ${NAME} -i -v ${LOCAL_PLUGINS_FOLDER}:/plugins -v ${LOCAL
 
 The ${LOCAL_PLUGINS_FOLDER} must have only .jar files. Folders and another file extensions will not be considered.
 
+### Configuring the custom JMeter plugins folder location
+
+It is also possible to define an alternate location to the custom JMeter plugins folder. Simply define a environment variable called `JMETER_CUSTOM_PLUGINS_FOLDER` with the desired folder path like in the example bellow:
+
+```sh
+sudo docker run --name ${NAME} -i -e JMETER_CUSTOM_PLUGINS_FOLDER=/jmeter/plugins -v ${LOCAL_PLUGINS_FOLDER}:/jmeter/plugins -v ${LOCAL_JMX_WORK_DIR}:${CONTAINER_JMX_WORK_DIR} -w ${PWD} ${IMAGE} $@
+```
+
+
 ## Do it for real: detailed build/run/test
 
 Contribution by @wilsonmar

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,9 @@
 #
 
 # Install jmeter plugins available on /plugins volume
-if [ -d /plugins ]
+if [ -d $JMETER_CUSTOM_PLUGINS_FOLDER ]
 then
-    for plugin in /plugins/*.jar; do
+    for plugin in ${JMETER_CUSTOM_PLUGINS_FOLDER}/*.jar; do
         cp $plugin ${JMETER_HOME}/lib/ext
     done;
 fi


### PR DESCRIPTION
This change was made to reduce the amount of volumes/folders that must be atached to the container to share the plugins and jmx files. So instead of binding 2 volumes: test files and plugins folder respectivelly, we bind a folder called, for example, jmeter that contains the folders test and plugins required to run.