### PR TITLE
fix: handle SIGTINT signal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ COPY entrypoint.sh /
 
 WORKDIR	${JMETER_HOME}
 
-ENTRYPOINT ["/entrypoint.sh"]
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/entrypoint.sh"]


### PR DESCRIPTION
Hi! First, thank you  for maintaining this repo 🙂

## Context / Issue

Cancelling a test plan with CTRL-C does not work. The container is not stopped, and the plan continues until it ends. This is problematic, especially if you make a mistake in the plan and want it to stop right away to prevent catastrophic consequences 😆

## Solution(s)

### 1/ First Solution

I tried replacing the following line in the entrypoint:
https://github.com/justb4/docker-jmeter/blob/17e6c2bd4b84c75f7a858d4465d121ff66a1b321/entrypoint.sh#L31
by this:
```bash
exec jmeter ${EXTRA_ARGS} $@
```
; in order to pass down signals to JMeter. This unfortunately does not work. It looks like either JMeter is not properly handling SIGTINT signals, or that JMeter waits for its threads to complete before gracefully shutting down its process.

### 1/ Second Solution

This is what I retained in this PR, simply use [tini](https://github.com/krallin/tini) to handle signals for us. This works.

Let me know what you think!
Thanks